### PR TITLE
Remove stray whitespace in request body key

### DIFF
--- a/src/app/ttrss-client.service.ts
+++ b/src/app/ttrss-client.service.ts
@@ -170,7 +170,7 @@ export class TtrssClientService {
 
   catchupFeed(feed: ICategory, is_cat: boolean): Observable<boolean> {
     const body = '{"sid":"' + this.settings.sessionKey + '", "op":"catchupFeed", "feed_id":"' + feed.bare_id +
-      '", "is_cat ": ' + is_cat + ' }';
+      '", "is_cat": ' + is_cat + ' }';
     const result = this.http.post<ApiResult<UpdateResult>>(this.settings.url, body);
     return result.pipe(
       map(data => {


### PR DESCRIPTION
I'm not sure if this causes problems in practice, but it's clearly wrong.